### PR TITLE
Add NTComplexTable

### DIFF
--- a/src/org/epics/nt/NTComplexTable.java
+++ b/src/org/epics/nt/NTComplexTable.java
@@ -1,0 +1,338 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+package org.epics.nt;
+
+import org.epics.pvdata.pv.Field;
+import org.epics.pvdata.pv.Scalar;
+import org.epics.pvdata.pv.ScalarArray;
+import org.epics.pvdata.pv.ScalarType;
+import org.epics.pvdata.pv.Structure;
+import org.epics.pvdata.pv.Type;
+import org.epics.pvdata.pv.Union;
+import org.epics.pvdata.pv.PVField;
+import org.epics.pvdata.pv.PVScalar;
+import org.epics.pvdata.pv.PVScalarArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.pvdata.pv.PVString;
+import org.epics.pvdata.pv.PVStringArray;
+import org.epics.pvdata.pv.PVUnionArray;
+import org.epics.pvdata.property.PVTimeStamp;
+import org.epics.pvdata.property.PVAlarm;
+
+/**
+ * Wrapper class for NTComplexTable.
+ *
+ * @author dgh
+ */
+public class NTComplexTable
+    implements HasTimeStamp, HasAlarm
+{
+    public static final String URI = "epics:nt/NTComplexTable:1.0";
+
+    /**
+     * Creates an NTComplexTable wrapping the specified PVStructure if the latter is compatible.
+     * <p>
+     * Checks the supplied PVStructure is compatible with NTComplexTable
+     * and if so returns an NTComplexTable which wraps it.
+     * This method will return null if the structure is is not compatible
+     * or is null.
+     *
+     * @param pvStructure the PVStructure to be wrapped
+     * @return NTComplexTable instance on success, null otherwise
+     */
+    public static NTComplexTable wrap(PVStructure pvStructure)
+    {
+        if (!isCompatible(pvStructure))
+            return null;
+        return wrapUnsafe(pvStructure);
+    }
+
+    /**
+     * Creates an NTComplexTable wrapping the specified PVStructure, regardless of the latter's compatibility.
+     * <p>
+     * No checks are made as to whether the specified PVStructure
+     * is compatible with NTComplexTable or is non-null.
+     *
+     * @param structure the PVStructure to be wrapped
+     * @return NTComplexTable instance
+     */
+    public static NTComplexTable wrapUnsafe(PVStructure structure)
+    {
+        return new NTComplexTable(structure);
+    }
+
+    /**
+     * Returns whether the specified Structure reports to be a compatible NTComplexTable.
+     * <p>
+     * Checks if the specified Structure reports compatibility with this
+     * version of NTComplexTable through its type ID, including checking version numbers.
+     * The return value does not depend on whether the structure is actually
+     * compatible in terms of its introspection type.
+     *
+     * @param structure the Structure to test
+     * @return (false,true) if (is not, is) a compatible NTComplexTable
+     */
+    public static boolean is_a(Structure structure)
+    {
+        return NTUtils.is_a(structure.getID(), URI);
+    }
+
+
+    /**
+     * Returns whether the specified PVStructure reports to be a compatible NTComplexTable.
+     * <p>
+     * Checks if the specified PVStructure reports compatibility with this
+     * version of NTComplexTable through its type ID, including checking version numbers.
+     * The return value does not depend on whether the structure is actually
+     * compatible in terms of its introspection type.
+     *
+     * @param pvStructure the PVStructure to test
+     * @return (false,true) if (is not, is) a compatible NTComplexTable
+     */
+    public static boolean is_a(PVStructure pvStructure)
+    {
+        return is_a(pvStructure.getStructure());
+    }
+
+    /**
+     * Returns whether the specified Structure is compatible with NTComplexTable.
+     * <p>
+     * Checks if the specified Structure is compatible with this version
+     * of NTComplexTable through the introspection interface.
+     *
+     * @param structure the Structure to test
+     * @return (false,true) if (is not, is) a compatible NTComplexTable
+     */
+    public static boolean isCompatible(Structure structure)
+    {
+        if (structure == null) return false;
+
+        Structure valueField = structure.getField(Structure.class, "value");
+        if (valueField == null)
+            return false;
+
+        for (Field field : valueField.getFields())
+        {
+            if (field.getType() != Type.unionArray) return false;
+        }
+
+        ScalarArray labelsField = structure.getField(ScalarArray.class, "labels");
+        if (labelsField == null)
+            return false;
+
+        if (labelsField.getElementType() != ScalarType.pvString)
+            return false;
+
+        Field field = structure.getField("descriptor");
+        if (field != null)
+        {
+            Scalar descriptorField = structure.getField(Scalar.class, "descriptor");
+            if (descriptorField == null || descriptorField.getScalarType() != ScalarType.pvString)
+                return false;
+        }
+
+        NTField ntField = NTField.get();
+
+        field = structure.getField("alarm");
+        if (field != null && !ntField.isAlarm(field))
+            return false;
+
+        field = structure.getField("timeStamp");
+        if (field != null && !ntField.isTimeStamp(field))
+            return false;
+
+        return true;
+    }
+
+    /**
+     * Returns whether the specified PVStructure is compatible with NTComplexTable.
+     *
+     * Checks if the specified PVStructure is compatible with this version
+     * of NTComplexTable through the introspection interface.
+     *
+     * @param pvStructure the PVStructure to test
+     * @return (false,true) if (is not, is) a compatible NTComplexTable
+     */
+    public static boolean isCompatible(PVStructure pvStructure)
+    {
+        if (pvStructure == null) return false;
+
+        return isCompatible(pvStructure.getStructure());
+    }
+
+    /**
+     * Returns whether the wrapped PVStructure is a valid NTComplexTable.
+     * <p>
+     * Unlike isCompatible(), isValid() may perform checks on the value
+     * data as well as the introspection data.
+     *
+     * @return (false,true) if wrapped PVStructure (is not, is) a valid NTComplexTable
+     */
+    public boolean isValid()
+    {
+        PVField[] columns = pvValue.getPVFields();
+        
+        if (getLabels().getLength() != columns.length) return false;
+        boolean first = true;
+        int length = 0;
+        for (PVField column : columns)
+        {
+            try
+            {
+                int colLength = ((PVScalarArray)column).getLength();
+                if (first)
+                {
+                    length = colLength;
+                    first = false;
+                }
+                else if (length != colLength)
+                    return false;
+            }
+            catch (ClassCastException e)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Creates an NTComplexTable builder instance.
+     *
+     * @return builder instance.
+     */
+    public static NTComplexTableBuilder createBuilder()
+    {
+        return new NTComplexTableBuilder();
+    }
+
+    /**
+     * Returns the PVStructure wrapped by this instance.
+     *
+     * @return the PVStructure wrapped by this instance
+     */
+    public PVStructure getPVStructure()
+    {
+        return pvNTComplexTable;
+    }
+
+    /**
+     * Returns the value field.
+     *
+     * @return the PVScalar for the value field
+     */
+    public PVStructure getValue()
+    {
+        return pvValue;
+    }
+
+    /**
+     * Returns the labels field.
+     *
+     * @return the labels field
+     */
+    public PVStringArray getLabels()
+    {
+       return pvNTComplexTable.getSubField(PVStringArray.class, "labels");
+    }
+
+    /**
+     * Returns the column names for the table.
+     *
+     * For each name, calling getColumn should return the column, which should not be null.
+     * @return the column names.
+     */
+    public String[] getColumnNames()
+    {
+       return pvValue.getStructure().getFieldNames();
+    }
+
+    /**
+     * Returns the the column with the specified colum name.
+     *
+     * @param columnName the name of the column.
+     * @return the field for the column or null if column does not exist.
+     */
+    public PVUnionArray getColumn(String columnName)
+    {
+       return pvValue.getSubField(PVUnionArray.class, columnName);
+    }
+
+    /**
+     * Returns the descriptor field.
+     *
+     * @return the descriptor field or null if no such field
+     */
+    public PVString getDescriptor()
+    {
+        return pvNTComplexTable.getSubField(PVString.class, "descriptor");
+    }
+
+    /* (non-Javadoc)
+	 * @see org.epics.pvdata.nt.HasAlarm#getAlarm()
+	 */
+    public PVStructure getAlarm()
+    {
+       return pvNTComplexTable.getSubField(PVStructure.class, "alarm");
+    }
+
+    /* (non-Javadoc)
+	 * @see org.epics.pvdata.nt.HasTimeStamp#getTimeStamp()
+	 */
+    public PVStructure getTimeStamp()
+    {
+        return pvNTComplexTable.getSubField(PVStructure.class, "timeStamp");
+    }
+
+
+    /* (non-Javadoc)
+	 * @see org.epics.pvdata.nt.HasAlarm#attachAlarm(org.epics.pvdata.property.PVAlarm)
+	 */
+    public boolean attachAlarm(PVAlarm pvAlarm)
+    {
+        PVStructure al = getAlarm();
+        if (al != null)
+            return pvAlarm.attach(al);
+        else
+            return false;
+    }
+
+    /* (non-Javadoc)
+	 * @see org.epics.pvdata.nt.HasTimeStamp#attachTimeStamp(org.epics.pvdata.property.PVTimeStamp)
+	 */
+    public boolean attachTimeStamp(PVTimeStamp pvTimeStamp)
+    {
+        PVStructure ts = getTimeStamp();
+        if (ts != null)
+            return pvTimeStamp.attach(ts);
+        else
+            return false;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */ 
+    public String toString()
+    {
+        return getPVStructure().toString();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param pvStructure the PVStructure to be wrapped
+     */
+    NTComplexTable(PVStructure pvStructure)
+    {
+        pvNTComplexTable = pvStructure;
+        pvValue = pvNTComplexTable.getSubField(PVStructure.class, "value");
+    }
+
+    private PVStructure pvNTComplexTable;
+    private PVStructure pvValue;
+}
+

--- a/src/org/epics/nt/NTComplexTableBuilder.java
+++ b/src/org/epics/nt/NTComplexTableBuilder.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright - See the COPYRIGHT that is included with this distribution.
+ * EPICS pvData is distributed subject to a Software License Agreement found
+ * in file LICENSE that is included with this distribution.
+ */
+package org.epics.nt;
+
+import org.epics.pvdata.pv.Field;
+import org.epics.pvdata.pv.FieldBuilder;
+import org.epics.pvdata.pv.FieldCreate;
+import org.epics.pvdata.pv.ScalarType;
+import org.epics.pvdata.pv.Structure;
+import org.epics.pvdata.pv.PVStringArray;
+import org.epics.pvdata.pv.PVStructure;
+import org.epics.pvdata.pv.PVUnionArray;
+import org.epics.pvdata.pv.Union;
+import org.epics.pvdata.factory.FieldFactory;
+import org.epics.pvdata.factory.PVDataFactory;
+import java.util.ArrayList;
+
+/**
+ * Interface for in-line creating of NTComplexTable.
+ *
+ * One instance can be used to create multiple instances.
+ * An instance of this object must not be used concurrently (an object has a state).
+ * @author dgh
+ */
+public class NTComplexTableBuilder
+{
+    /**
+     * Adds a column of a given Union to the NTComplexTable.
+     *
+     * @param name the name of the column
+     * @param elementType the introspection type of the union array elements of the column
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder addColumn(String name, Union elementType)
+    {
+        // TODO: check for duplicate columns
+
+        columnNames.add(name);
+        types.add(elementType);
+
+        return this;
+    }
+
+    /**
+     * Adds a column of variant union type to the NTComplexTable.
+     *
+     * @param name the name of the column
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder addColumn(String name)
+    {
+        return add(name, variantUnion);
+    }
+
+    /**
+     * Adds columns, each of a given Union, to the NTComplexTable.
+     * 
+     * @param names  the names of the columns
+     * @param unions the types of the union elements of the columns
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder addColumns(String[] names, Union[] unions)
+    {
+        // TODO: check for duplicate columns
+
+        if (names.length != unions.length)
+            throw new RuntimeException("Column name and type lengths must match)");
+
+        for (int i = 0; i < names.length; ++i)
+            addColumn(names[i], unions[i]);
+
+        return this;
+    }
+
+    /**
+     * Adds columns, each of variant union type, to the NTComplexTable.
+     * 
+     * @param names  the names of the columns
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder addColumns(String[] names)
+    {
+        // TODO: check for duplicate columns
+
+        for (int i = 0; i < names.length; ++i)
+            addColumn(names[i], variantUnion);
+
+        return this;
+    }
+
+
+    /**
+     * Adds descriptor field to the NTComplexTable.
+     * 
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder addDescriptor()
+    {
+        descriptor = true;
+        return this;
+    }
+
+    /**
+     * Adds alarm field to the NTComplexTable.
+     * 
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder addAlarm()
+    {
+        alarm = true;
+        return this;
+    }
+
+    /**
+     * Adds timeStamp field to the NTComplexTable.
+     * 
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder addTimeStamp()
+    {
+        timeStamp = true;
+        return this;
+    }
+
+    /**
+     * Creates a Structure that represents NTComplexTable.
+     * This resets this instance state and allows new instance to be created.
+     * 
+     * @return a new instance of a Structure
+     */
+    public Structure createStructure()
+    {
+        FieldBuilder builder =
+            FieldFactory.getFieldCreate().createFieldBuilder();
+
+        FieldBuilder nestedBuilder = builder.
+               setId(NTComplexTable.URI).
+               addArray("labels", ScalarType.pvString).
+               addNestedStructure("value");
+
+        int len = columnNames.size();
+        for (int i = 0; i < len; i++)
+           nestedBuilder.addArray(columnNames.get(i), types.get(i));
+
+        builder = nestedBuilder.endNested();
+
+        NTField ntField = NTField.get();
+
+        if (descriptor)
+            builder.add("descriptor", ScalarType.pvString);
+
+        if (alarm)
+            builder.add("alarm", ntField.createAlarm());
+
+        if (timeStamp)
+            builder.add("timeStamp", ntField.createTimeStamp());
+
+        int extraCount = extraFieldNames.size();
+        for (int i = 0; i < extraCount; i++)
+            builder.add(extraFieldNames.get(i), extraFields.get(i));
+
+        Structure s = builder.createStructure();
+
+        reset();
+        return s;
+    }
+
+    /**
+     * Creates a PVStructure that represents NTComplexTable.
+     * This resets this instance state and allows new instance to be created
+     *
+     * @return a new instance of a PVStructure
+     */
+    public PVStructure createPVStructure()
+    {
+        // put the column names in labels by default
+        String[] labelArray = columnNames.toArray(new String[columnNames.size()]);
+
+        PVStructure s = PVDataFactory.getPVDataCreate().createPVStructure(
+            createStructure());
+
+        s.getSubField(PVStringArray.class, "labels").put(
+            0, labelArray.length, labelArray, 0);
+
+        return s;
+    }
+
+    /**
+     * Creates an NTComplexTable instance.
+     * This resets this instance state and allows new instance to be created
+     *
+     * @return a new instance of an NTComplexTable
+     */
+    public NTComplexTable create()
+    {
+        return new NTComplexTable(createPVStructure());
+    }
+
+    /**
+     * Adds extra Field to the type.
+     *
+     * @param name the name of the field
+     * @param field the field to add
+     * @return this instance of NTComplexTableBuilder
+     */
+    public NTComplexTableBuilder add(String name, Field field) 
+    {
+        extraFields.add(field);
+        extraFieldNames.add(name);
+        return this;
+    }
+
+    NTComplexTableBuilder()
+    {
+        reset();
+    }
+
+    private void reset()
+    {
+        columnNames.clear();
+        types.clear();
+        descriptor = false;
+        alarm = false;
+        timeStamp = false;
+        extraFieldNames.clear();
+        extraFields.clear();
+    }
+
+    // NOTE: this preserves order, however it does not handle duplicates
+    private ArrayList<String> columnNames = new ArrayList<String>();
+    private ArrayList<Union> types = new ArrayList<Union>();
+
+    private boolean descriptor;
+    private boolean alarm;
+    private boolean timeStamp;
+
+    // NOTE: this preserves order, however it does not handle duplicates
+    private ArrayList<String> extraFieldNames = new ArrayList<String>();
+    private ArrayList<Field> extraFields = new ArrayList<Field>();
+
+    static private Union variantUnion = FieldFactory.getFieldCreate().createVariantUnion();
+}
+


### PR DESCRIPTION
Add wrapper class for NTComplexTable.

Based on NTTable wrapper with unions replacing scalars, except has an extra default addColumn method which adds a variant union array column as a sensible default.

Not urgent to merge this - just to get a definition in code first. Murali/Greg is this what you want in terms of definition?

Working on unit tests, but not quite ready to push yet. Will add these before merge.
